### PR TITLE
Case Sensitive URL fixed.

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
                                 <div class="portfolio-hover">
                                     <div class="portfolio-hover-content"><i class="fas fa-plus fa-3x"></i></div>
                                 </div>
-                                <img class="img-fluid" src="assets/img/portfolio/COVID-19.jpg" alt="" />
+                                <img class="img-fluid" src="assets/img/portfolio/covid-19.jpg" alt="" />
                             </a>
                             <div class="portfolio-caption">
                                 <div class="portfolio-caption-heading">COVID19 Forecast</div>


### PR DESCRIPTION
The URLs in GitHub Pages are case sensitive. The COVID 19 project you made didn't work:

![image](https://user-images.githubusercontent.com/1830380/96882417-30f5a200-1477-11eb-8e45-b59649938617.png)

So I made this small change that makes it right:

![image](https://user-images.githubusercontent.com/1830380/96882502-47036280-1477-11eb-85c4-1abd23cf4165.png)

Feel free to accept and merge or close it. 😁